### PR TITLE
fix: format options present themselves in the options

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -1308,13 +1308,13 @@
         "message": "Title Case"
     },
     "SentenceCase": {
-        "message": "Sentence Case"
+        "message": "Sentence case"
     },
     "LowerCase": {
-        "message": "Lower Case"
+        "message": "lower case"
     },
     "FirstLetterUppercase": {
-        "message": "First Letter Uppercase"
+        "message": "First letter uppercase"
     },
     "shouldCleanEmojis": {
         "message": "Remove Emojis"


### PR DESCRIPTION
Update the options in Title Format to give something of a preview of the result.