### PR TITLE
Fix typo in German translation of hideDetailsWhileFetchingDescription

### DIFF
--- a/de/messages.json
+++ b/de/messages.json
@@ -1400,7 +1400,7 @@
         "message": "Details während des Abrufs ausblenden"
     },
     "hideDetailsWhileFetchingDescription": {
-        "message": "Blende Titel und Thumbnails während des Abrufens von Datem vom Server aus. Wenn deaktiviert wirst du aufblinkende Titel und Thumbnails sehen während diese sich ändern."
+        "message": "Blende Titel und Thumbnails während des Abrufens von Daten vom Server aus. Wenn deaktiviert wirst du aufblinkende Titel und Thumbnails sehen während diese sich ändern."
     },
     "onAllPages": {
         "message": "Auf allen Seiten",


### PR DESCRIPTION
So this is a one-letter change but I thought I would save you the trouble :)
I noticed a typo in the German translation for the key `hideDetailsWhileFetchingDescription`. 
Instead of *Blende Titel und Thumbnails während des Abrufens von Date**m** vom Server aus.* it should be *Blende Titel und Thumbnails während des Abrufens von Date**n** vom Server aus.*