### PR TITLE
Update Non-Music category description

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -753,7 +753,7 @@
         "message": "Music: Non-Music Section"
     },
     "category_music_offtopic_description": {
-        "message": "Only for use in music videos. This only should be used for sections of music videos that aren't already covered by another category."
+        "message": "Only for use in music videos. This category exists detached from other categories and is allowed to overlap with other categegories."
     },
     "category_music_offtopic_short": {
         "message": "Non-Music"


### PR DESCRIPTION
in messages.json: category_music_offtopic_description is not correct.
Update it to "Only for use in music videos. This category exists detached from other categories and is allowed to overlap with other categegories."
which corresponds to version wiki version https://wiki.sponsor.ajay.app/index.php?title=Music:_Non-Music_Section&oldid=3831
